### PR TITLE
update spellcheck config

### DIFF
--- a/.spellcheck.yml
+++ b/.spellcheck.yml
@@ -9,14 +9,13 @@ matrix:
     encoding: utf-8
   pipeline:
   - pyspelling.filters.markdown:
+      markdown_extensions:
+      - markdown.extensions.fenced_code:
   - pyspelling.filters.html:
       comments: false
-      attributes:
-      - title
-      - alt
       ignores:
-      - code
       - pre
+      - code
   sources:
   - '!venv/**/*.md|**/*.md'
   default_encoding: utf-8


### PR DESCRIPTION
Update spellcheck config to ignore code blocks.
By default python markdown does not recognise fenced code by default:
https://codesti.com/issue/facelessuser/pyspelling/156#168826773

To fix this, we enable the fenced code extension.